### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 * [Build History](https://github.com/ProxymanApp/Proxyman/releases)
 
 ```
-$ brew cask install proxyman
+$ brew install --cask proxyman
 ```
 
 ## Have a problem?


### PR DESCRIPTION
`brew cask install proxyman` doesn't work now because of update of Homebrew.
This is not a bug of this app, but the document needs to be fixed.

[Error: Calling brew cask install is disabled! · Discussion #340 · Homebrew/discussions](https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364)

> `brew cask <command>` was deprecated in favor of `brew <command> --cask` in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled.
