### PR TITLE
Correct GitHub spelling and another typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <h2 align="center">Modern. Native. Web Debugging Proxy for macOS. Support iOS and Android ⚡️</h2>
+  <h2 align="center">Modern. Native. Web Debugging Proxy for macOS. Supports iOS and Android ⚡️</h2>
 </p>
 
 <img src="https://raw.githubusercontent.com/ProxymanApp/Proxyman/master/screenshots/proxyman_dashboard_4.8.1.jpg" alt="Proxyman Dashboard" width="100%" height="auto"/>
@@ -22,7 +22,7 @@
 
 ## Features
 * 💻 Native macOS app. Written by Swift, Objective-C. Powered by Apple SwiftNIO for the high-performance network application.
-* 🍎 Fully support Apple Chip (e.g M1, M2, M3). 
+* 🍎 Fully supports Apple Chip (e.g M1, M2, M3). 
 * 💫 Built for macOS Ventura & Sonoma.
 * ✅ Hassle-free Intercept HTTP/HTTPS requests/response and WebSocket from Web Browsers, iOS, and Android devices.
 * ✅ Modern and intuitive UI
@@ -50,7 +50,7 @@ $ brew install --cask proxyman
 
 ## Have a problem?
 
-- Open a Github ticket
+- Open a GitHub ticket
 - Technical issues on [![Gitter](https://badges.gitter.im/Proxyman-app/community.svg)](https://gitter.im/Proxyman-app/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 - nghia@proxyman.io & support@proxyman.io
 


### PR DESCRIPTION
BTW, "GitHub" is also misspelled in a few places on https://proxyman.io, but I'm not sure where to find that webpage's source.

![image](https://github.com/ProxymanApp/Proxyman/assets/217368/8e15694c-9441-4277-9e70-cca3e0ddc6a4)
![image](https://github.com/ProxymanApp/Proxyman/assets/217368/e479bf4e-2884-407c-b3ec-c3cdc8879f13)

Hope it helps :)