### PR TITLE
remove $ from command for easier copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * [Full Changelogs](https://github.com/ProxymanApp/Proxyman/releases)
 
 ```
-$ brew install --cask proxyman
+brew install --cask proxyman
 ```
 
 ### Proxyman for iOS


### PR DESCRIPTION
When you copy the installation command there is `$` in the beginning that interferes just to run the command.